### PR TITLE
Support mac again

### DIFF
--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -13,15 +13,14 @@
 
 #ifdef _MSC_VER
 # define ALWAYS_INLINE // __forceinline
-# define ALIGNED_MALLOC(size, alignment) _aligned_malloc(size, alignment)
-# define FREE(ptr) _aligned_free(ptr)
 #else
 # define ALWAYS_INLINE __attribute__((always_inline))
-# define ALIGNED_MALLOC(size, alignment) aligned_alloc(alignment, size)
-# define FREE(ptr) free(ptr)
 #endif
 
 namespace fbgemm {
+
+void * genericAlignedAlloc(size_t size, size_t alignment);
+void genericFree(void * ptr);
 
 /**
  * @brief Helper struct to type specialize for uint8 and int8 together.

--- a/src/FbgemmI8Depthwise3DAvx2.cc
+++ b/src/FbgemmI8Depthwise3DAvx2.cc
@@ -490,7 +490,7 @@ static inline ALWAYS_INLINE void depthwise_3x3x3_pad_1_(
 
   //int32_t row_offsets[(K + 31) / 32 * 32] __attribute__((aligned(64)));
   int32_t* row_offsets
-      = static_cast<int32_t*>(ALIGNED_MALLOC((K + 31) / 32 * 32 * sizeof(int32_t), 64));
+      = static_cast<int32_t*>(genericAlignedAlloc((K + 31) / 32 * 32 * sizeof(int32_t), 64));
 
   int n_begin, n_end;
   int t_begin, t_end, h_begin, h_end;
@@ -568,7 +568,7 @@ static inline ALWAYS_INLINE void depthwise_3x3x3_pad_1_(
       } // h
     } // t
   } // for each n
-  FREE(row_offsets);
+  genericFree(row_offsets);
 };
 
 template <bool FUSE_RELU, bool HAS_BIAS, bool A_SYMMETRIC, typename BIAS_TYPE>
@@ -606,7 +606,7 @@ depthwise_3x3x3_per_channel_quantization_pad_1_(
 
   //int32_t row_offsets[(K + 31) / 32 * 32] __attribute__((aligned(64)));
   int32_t* row_offsets
-      = static_cast<int32_t*>(ALIGNED_MALLOC((K + 31) / 32 * 32 * sizeof(int32_t), 64));
+      = static_cast<int32_t*>(genericAlignedAlloc((K + 31) / 32 * 32 * sizeof(int32_t), 64));
 
   int n_begin, n_end;
   int t_begin, t_end, h_begin, h_end;
@@ -684,7 +684,7 @@ depthwise_3x3x3_per_channel_quantization_pad_1_(
       } // h
     } // t
   } // for each n
-  FREE(row_offsets);
+  genericFree(row_offsets);
 };
 
 // Dispatch A_SYMMETRIC and B_SYMMETRIC

--- a/src/FbgemmI8DepthwiseAvx2.cc
+++ b/src/FbgemmI8DepthwiseAvx2.cc
@@ -344,7 +344,7 @@ static inline ALWAYS_INLINE void depthwise_3x3_pad_1_(
   int W_OUT = (W + PAD_L + PAD_R - S) / stride_w + 1;
   const int8_t* Bp = B.PackedMat();
 
-  int32_t* row_offsets = static_cast<int32_t *>(ALIGNED_MALLOC(((K + 31) / 32 * 32)*sizeof(int32_t), 64));
+  int32_t* row_offsets = static_cast<int32_t *>(genericAlignedAlloc(((K + 31) / 32 * 32)*sizeof(int32_t), 64));
 
   int n_begin, n_end;
   int h_begin, h_end, w_begin, w_end;
@@ -655,7 +655,7 @@ static inline ALWAYS_INLINE void depthwise_3x3_pad_1_(
       }
     }
   } // for each n
-  FREE(row_offsets);
+  genericFree(row_offsets);
 };
 
 template <bool FUSE_RELU, bool HAS_BIAS, bool A_SYMMETRIC, typename BIAS_TYPE>
@@ -687,7 +687,7 @@ depthwise_3x3_per_channel_quantization_pad_1_(
   int W_OUT = (W + PAD_L + PAD_R - S) / stride_w + 1;
   const int8_t* Bp = B.PackedMat();
 
-  int32_t* row_offsets = static_cast<int32_t*>(ALIGNED_MALLOC(((K + 31) / 32 * 32)*sizeof(int32_t), 64)); // __attribute__((aligned(64)));
+  int32_t* row_offsets = static_cast<int32_t*>(genericAlignedAlloc(((K + 31) / 32 * 32)*sizeof(int32_t), 64)); // __attribute__((aligned(64)));
 
   int n_begin, n_end;
   int h_begin, h_end, w_begin, w_end;

--- a/src/FbgemmI8Spmdm.cc
+++ b/src/FbgemmI8Spmdm.cc
@@ -151,15 +151,15 @@ void CompressedSparseColumn::SpMDM(
   t_start = std::chrono::high_resolution_clock::now();
 #endif
 
-  uint8_t* A_buffer = static_cast<uint8_t*>(ALIGNED_MALLOC(K * 32 * sizeof(uint8_t), 64));
-  int32_t* C_buffer = static_cast<int32_t*>(ALIGNED_MALLOC(N * 32 * sizeof(int32_t), 64));
+  uint8_t* A_buffer = static_cast<uint8_t*>(genericAlignedAlloc(K * 32 * sizeof(uint8_t), 64));
+  int32_t* C_buffer = static_cast<int32_t*>(genericAlignedAlloc(N * 32 * sizeof(int32_t), 64));
 
   // Take 32 rows at a time
   int i_end = block.row_start + block.row_size;
   for (int i1 = block.row_start; i1 < i_end; i1 += 32) {
     // Transpose 32 x K submatrix of A
     if (i_end - i1 < 32) {
-      uint8_t* A_temp_buffer = static_cast<uint8_t*>(ALIGNED_MALLOC(K * 32 * sizeof(uint8_t), 64));
+      uint8_t* A_temp_buffer = static_cast<uint8_t*>(genericAlignedAlloc(K * 32 * sizeof(uint8_t), 64));
       for (int i2 = 0; i2 < (i_end - i1) / 8 * 8; i2 += 8) {
         transpose_8rows(K, A + (i1 + i2) * lda, lda, A_buffer + i2, 32);
       }
@@ -175,7 +175,7 @@ void CompressedSparseColumn::SpMDM(
       for (int i2 = (i_end - i1) / 8 * 8; i2 < 32; i2 += 8) {
         transpose_8rows(K, A_temp_buffer + i2 * K, K, A_buffer + i2, 32);
       }
-      FREE(A_temp_buffer);
+      genericFree(A_temp_buffer);
     } else {
       for (int i2 = 0; i2 < 32; i2 += 8) {
         transpose_8rows(K, A + (i1 + i2) * lda, lda, A_buffer + i2, 32);
@@ -254,8 +254,8 @@ void CompressedSparseColumn::SpMDM(
   t_start = std::chrono::high_resolution_clock::now();
 #endif
 
-  FREE(A_buffer);
-  FREE(C_buffer);
+  genericFree(A_buffer);
+  genericFree(C_buffer);
 }
 
 void CompressedSparseColumn::SparseConv(

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -17,6 +17,30 @@
 
 namespace fbgemm {
 
+void * genericAlignedAlloc(size_t size, size_t align) {
+  void* aligned_mem = nullptr;
+  int ret;
+#ifdef _MSC_VER
+  aligned_mem = _aligned_malloc(size, align);
+  ret = 0;
+#else
+  ret = posix_memalign(&aligned_mem, align, size);
+#endif
+  // Throw std::bad_alloc in the case of memory allocation failure.
+  if (ret || aligned_mem == nullptr) {
+    throw std::bad_alloc();
+  }
+  return aligned_mem;
+}
+
+void genericFree(void * p) {
+#ifdef _MSC_VER
+  _aligned_free(p);
+#else
+  free(p);
+#endif
+}
+
 /**
  * @brief Compare the reference and test result matrix to check the correctness.
  * @param ref The buffer for the reference result matrix.


### PR DESCRIPTION
Hey,

For some reason, marian's fork of `fbgemm` has lost mac support, due to issues with aligned_alloc.

I have changed the allocator similar to master, except the argument order is reversed.  https://github.com/pytorch/FBGEMM/blob/master/src/Utils.cc#L406 

Is there any reason why this is not part of master?

Cheers,

Nick