### PR TITLE
Remove an unnecessary memory allocation

### DIFF
--- a/src/PackAWithQuantRowOffset.cc
+++ b/src/PackAWithQuantRowOffset.cc
@@ -116,8 +116,9 @@ void PackAWithQuantRowOffset<T, accT>::pack(const block_type_t& block) {
       (block.col_start % (this->numCols() / this->numGroups())) != 0;
   int32_t* row_offset_buf = getRowOffsetBuffer();
 
-  float* smat_transposed = new float[block.row_size * block.col_size];
+  float* smat_transposed = nullptr;
   if (tr) {
+    smat_transposed = new float[block.row_size * block.col_size];
     transpose_simd(
         block.col_size,
         block.row_size,
@@ -156,7 +157,8 @@ void PackAWithQuantRowOffset<T, accT>::pack(const block_type_t& block) {
     }
   }
 
-  delete[] smat_transposed;
+  if (smat_transposed)
+    delete[] smat_transposed;
 }
 
 template <typename T, typename accT>


### PR DESCRIPTION
There is a memory allocation which is used for matrix transpose.
This memory allocation/deallocation is not necessary for non-transposed input matrix which is the most case in marian.

This potentially cause a memory contention problem when the load is increased in a heavily multi-threaded environment.