### PR TITLE
Add GCC 11 support.

### DIFF
--- a/src/RefImplementations.cc
+++ b/src/RefImplementations.cc
@@ -12,6 +12,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstring>
+#include <limits>
 
 using namespace std;
 


### PR DESCRIPTION
GCC11 now explicitly requires inclusion of <memory> <thread> <limits> and <utility> breaking some older code