### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,4 @@
 [submodule "third_party/googletest"]
 	path = third_party/googletest
 	url = https://github.com/google/googletest
+	branch = main


### PR DESCRIPTION
googletest seems to have changed from `master` to `main`. This breaks submodule initialization (at least for me)