### PR TITLE
Fix compilation of latest gcc, where uint32_t is not defined by default

### DIFF
--- a/include/fbgemm/Utils.h
+++ b/include/fbgemm/Utils.h
@@ -8,6 +8,7 @@
 #include <array>
 #include <string>
 #include <type_traits>
+#include <cstdint>
 #include "FbgemmBuild.h"
 #include "UtilsAvx2.h"
 

--- a/include/fbgemm/UtilsAvx2.h
+++ b/include/fbgemm/UtilsAvx2.h
@@ -9,6 +9,7 @@
 // flags.
 
 #include <string>
+#include <cstdint>
 
 namespace fbgemm {
 


### PR DESCRIPTION
Compilation fails on latest GCC due to cstdint not being included by default.